### PR TITLE
Mission planner

### DIFF
--- a/experiments/WebUI/src/assets/MapIcons.js
+++ b/experiments/WebUI/src/assets/MapIcons.js
@@ -5,6 +5,11 @@ const mapPin = new L.Icon({
     iconSize: new L.Point(10, 10)
 });
 
+const mapPinSelected = new L.Icon({
+    iconUrl: require('./img/map-pin-selected.svg'),
+    iconSize: new L.Point(10, 10)
+});
+
 const readyMarker = new L.Icon({
     iconUrl: require('./img/map-marker-alt-solid.svg'),
     iconSize: new L.Point(20, 20)
@@ -15,4 +20,4 @@ const notReadyMarker = new L.Icon({
     iconSize: new L.Point(20, 20)
 });
 
-export { mapPin, readyMarker, notReadyMarker };
+export { mapPin, mapPinSelected, readyMarker, notReadyMarker };

--- a/experiments/WebUI/src/assets/MissionPlanner.css
+++ b/experiments/WebUI/src/assets/MissionPlanner.css
@@ -49,3 +49,17 @@ ul {
 	cursor: pointer;
 	margin-left: 20px;
 }
+
+.cancelAddMissionBtn{
+	margin: 10px;
+	cursor: pointer;
+	color: red;
+	font-size: 1.3em;
+}
+
+.saveNewMissionBtn{
+	margin: 10px;
+	cursor: pointer;
+	color: green;
+	font-size: 1.3em;
+}

--- a/experiments/WebUI/src/assets/img/map-pin-selected.svg
+++ b/experiments/WebUI/src/assets/img/map-pin-selected.svg
@@ -1,0 +1,1 @@
+<svg aria-hidden="true" focusable="false" color="#ecf542" data-prefix="fas" data-icon="circle" class="svg-inline--fa fa-circle fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z"></path></svg>

--- a/experiments/WebUI/src/components/content/MLegInfoComponent.js
+++ b/experiments/WebUI/src/components/content/MLegInfoComponent.js
@@ -18,10 +18,10 @@ const styles = StyleSheet.create({
 class MLegInfoComponent extends React.Component {
 	constructor(props, context) {
 		super(props, context);
-		// Make deep copy of missionLeg object so that changes dont get saved instantly.
-		var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
+		// // Make deep copy of missionLeg object so that changes dont get saved instantly.
+		// var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
 		this.state = {
-			missionLeg: missionLeg,
+			missionLeg: this.props.missionLeg,
 			editMode: this.props.editMode
 		}
 	}
@@ -30,10 +30,10 @@ class MLegInfoComponent extends React.Component {
 		if (prevProps.missionLeg !== this.props.missionLeg) {
 			// console.log(this.state.missionLeg);
 
-			// Make deep copy of missionLeg object so that changes dont get saved instantly.
-			var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
+			// // Make deep copy of missionLeg object so that changes dont get saved instantly.
+			// var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
 			this.setState({
-				missionLeg: missionLeg,
+				missionLeg: this.props.missionLeg,
 				editMode: this.props.editMode
 			});
 		}
@@ -42,10 +42,16 @@ class MLegInfoComponent extends React.Component {
 	onPropertyChange(e) {
 		var missionLeg = this.state.missionLeg;
 		// console.log(e.target.value);
-		missionLeg.mp[e.target.name] = parseFloat(e.target.value);
+		var value = e.target.value;
+		if (value === "") {
+			value = 0;
+		}
+		missionLeg.mp[e.target.name] = parseFloat(value);
 		this.setState({
 			missionLeg: missionLeg
 		});
+
+		this.props.refreshMissionMarkersFunc(this.props.missionIndex-1);
 	}
 
 	onParamChange(e) {
@@ -64,26 +70,26 @@ class MLegInfoComponent extends React.Component {
 		});
 	}
 
-	saveChanges() {
-		// creating a copy of the state.missionLeg and then assigning it to props.missionLeg to prevent further direct modification to props.missionLeg which would have pointed to state.missionLeg due to assign.
-		Object.assign(this.props.missionLeg, JSON.parse(JSON.stringify(this.state.missionLeg)));
-		// console.log(this.props.missionIndex);
-		this.props.refreshMissionMarkersFunc(this.props.missionIndex-1);
-	}
-
-	discardChanges() {
-		var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
-		this.setState({
-			missionLeg: missionLeg,
-			editMode: this.props.editMode
-		});
-	}
+	// saveChanges() {
+	// 	// creating a copy of the state.missionLeg and then assigning it to props.missionLeg to prevent further direct modification to props.missionLeg which would have pointed to state.missionLeg due to assign.
+	// 	Object.assign(this.props.missionLeg, JSON.parse(JSON.stringify(this.state.missionLeg)));
+	// 	// console.log(this.props.missionIndex);
+	// 	this.props.refreshMissionMarkersFunc(this.props.missionIndex-1);
+	// }
+	//
+	// discardChanges() {
+	// 	var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
+	// 	this.setState({
+	// 		missionLeg: missionLeg,
+	// 		editMode: this.props.editMode
+	// 	});
+	// }
 
 	render() {
 		var propertyTableRows = [];
 		var paramTableRows = [];
 		var payloadObject = {};
-		var actionButtons = null;
+		// var actionButtons = null;
 		if (this.state.missionLeg !== null) {
 
 			//Property table - TODO currently hard coded, find better way to do this.
@@ -123,10 +129,10 @@ class MLegInfoComponent extends React.Component {
 
 			payloadObject = this.state.missionLeg.payload;
 
-			actionButtons = <div>
-				<Button variant="success" onClick={() => this.saveChanges()}>Save Changes</Button>
-				<Button variant="danger" onClick={() => this.discardChanges()}>Discard Changes</Button>
-			</div>;
+			// actionButtons = <div>
+			// 	<Button variant="success" onClick={() => this.saveChanges()}>Save Changes</Button>
+			// 	<Button variant="danger" onClick={() => this.discardChanges()}>Discard Changes</Button>
+			// </div>;
 		}
 
 		const Properties =
@@ -180,7 +186,7 @@ class MLegInfoComponent extends React.Component {
 						</Tab.Pane>
 					</Tab.Content>
 				</Tab.Container>
-				{actionButtons}
+				{/* {actionButtons} */}
 			</div>
 		);
 	}

--- a/experiments/WebUI/src/components/content/MLegInfoComponent.js
+++ b/experiments/WebUI/src/components/content/MLegInfoComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, css } from 'aphrodite';
-import { Table, ListGroup, Tab } from 'react-bootstrap';
+import { Table, ListGroup, Tab, FormControl, Button } from 'react-bootstrap';
 
 
 const styles = StyleSheet.create({
@@ -18,32 +18,130 @@ const styles = StyleSheet.create({
 class MLegInfoComponent extends React.Component {
 	constructor(props, context) {
 		super(props, context);
+		// Make deep copy of missionLeg object so that changes dont get saved instantly.
+		var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
 		this.state = {
-			activeSegment: "Parameters"
+			missionLeg: missionLeg,
+			editMode: this.props.editMode
 		}
 	}
 
+	componentDidUpdate(prevProps) {
+		if (prevProps.missionLeg !== this.props.missionLeg) {
+			// console.log(this.state.missionLeg);
+
+			// Make deep copy of missionLeg object so that changes dont get saved instantly.
+			var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
+			this.setState({
+				missionLeg: missionLeg,
+				editMode: this.props.editMode
+			});
+		}
+	}
+
+	onPropertyChange(e) {
+		var missionLeg = this.state.missionLeg;
+		// console.log(e.target.value);
+		missionLeg.mp[e.target.name] = parseFloat(e.target.value);
+		this.setState({
+			missionLeg: missionLeg
+		});
+	}
+
+	onParamChange(e) {
+		var missionLeg = this.state.missionLeg;
+		missionLeg.mp.params[e.target.name] = e.target.value;
+		this.setState({
+			missionLeg: missionLeg
+		});
+	}
+
+	onPayloadChange(e) {
+		var missionLeg = this.state.missionLeg;
+		missionLeg.payload = e.target.value;
+		this.setState({
+			missionLeg: missionLeg
+		});
+	}
+
+	saveChanges() {
+		// creating a copy of the state.missionLeg and then assigning it to props.missionLeg to prevent further direct modification to props.missionLeg which would have pointed to state.missionLeg due to assign.
+		Object.assign(this.props.missionLeg, JSON.parse(JSON.stringify(this.state.missionLeg)));
+		// console.log(this.props.missionIndex);
+		this.props.refreshMissionMarkersFunc(this.props.missionIndex-1);
+	}
+
+	discardChanges() {
+		var missionLeg = JSON.parse(JSON.stringify(this.props.missionLeg));
+		this.setState({
+			missionLeg: missionLeg,
+			editMode: this.props.editMode
+		});
+	}
 
 	render() {
-		var tableRows = [];
+		var propertyTableRows = [];
+		var paramTableRows = [];
 		var payloadObject = {};
-		if (this.props.missionLeg !== null) {
-			// console.log(this.props.missionLeg);
-			var params = this.props.missionLeg.mp.params;
+		var actionButtons = null;
+		if (this.state.missionLeg !== null) {
+
+			//Property table - TODO currently hard coded, find better way to do this.
+			propertyTableRows.push(
+				<tr>
+					<td>x</td>
+					<td><FormControl name="x" onChange={(e) => this.onPropertyChange(e)} value={this.state.missionLeg.mp.x}></FormControl></td>
+				</tr>
+			);
+			propertyTableRows.push(
+				<tr>
+					<td>y</td>
+					<td><FormControl name="y" onChange={(e) => this.onPropertyChange(e)} value={this.state.missionLeg.mp.y}></FormControl></td>
+				</tr>
+			);
+			propertyTableRows.push(
+				<tr>
+					<td>z</td>
+					<td><FormControl name="z" onChange={(e) => this.onPropertyChange(e)} value={this.state.missionLeg.mp.z}></FormControl></td>
+				</tr>
+			);
+
+			// console.log(this.state.missionLeg);
+			var params = this.state.missionLeg.mp.params;
 			for (var key in params) {
 				if (params.hasOwnProperty(key)) {
-					tableRows.push
+					paramTableRows.push
 					(
-						<tr>
+						<tr key={key}>
 							<td>{key}</td>
-							<td>{params[key]}</td>
+							{/* <td><div contentEditable={this.props.editMode}>{params[key]}</div></td> */}
+							<td><FormControl name={key} onChange={(e) => this.onParamChange(e)} value={params[key]}></FormControl></td>
 						</tr>
 					);
 				}
 			}
 
-			payloadObject = this.props.missionLeg.payload;
+			payloadObject = this.state.missionLeg.payload;
+
+			actionButtons = <div>
+				<Button variant="success" onClick={() => this.saveChanges()}>Save Changes</Button>
+				<Button variant="danger" onClick={() => this.discardChanges()}>Discard Changes</Button>
+			</div>;
 		}
+
+		const Properties =
+			<Table striped bordered hover>
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					{propertyTableRows}
+				</tbody>
+			</Table>;
+
 		const Parameters =
 			<Table striped bordered hover>
 				<thead>
@@ -53,13 +151,13 @@ class MLegInfoComponent extends React.Component {
 					</tr>
 				</thead>
 				<tbody>
-					{tableRows}
+					{paramTableRows}
 				</tbody>
 			</Table>;
 
 		const Payload =
 			<div>
-				{JSON.stringify(payloadObject, null, 4)}
+				<FormControl onChange={(e) => this.onPayloadChange(e)} value={JSON.stringify(payloadObject, null, 0)}></FormControl>
 			</div>;
 		return (
 			<div className={css(styles.MLegInfoContainer)}>
@@ -72,7 +170,7 @@ class MLegInfoComponent extends React.Component {
 
 					<Tab.Content>
 						<Tab.Pane eventKey="#Property">
-
+							{Properties}
 						</Tab.Pane>
 						<Tab.Pane eventKey="#Parameters">
 							{Parameters}
@@ -82,6 +180,7 @@ class MLegInfoComponent extends React.Component {
 						</Tab.Pane>
 					</Tab.Content>
 				</Tab.Container>
+				{actionButtons}
 			</div>
 		);
 	}

--- a/experiments/WebUI/src/components/content/MapComponent.js
+++ b/experiments/WebUI/src/components/content/MapComponent.js
@@ -132,7 +132,8 @@ class MapComponent extends React.Component {
 
 			missions: null, //all missions
 			newMission: [],
-			selectedMissionPoint: 0
+			selectedMissionPoint: 0,
+			displayMissionPlanner: false
 
 		};
 
@@ -165,6 +166,8 @@ class MapComponent extends React.Component {
 		// this.missions = null;
 
 		this.selectMissionPoint = this.selectMissionPoint.bind(this);
+
+		this.toggleMissionPlanner = this.toggleMissionPlanner.bind(this);
 	}
 
 	componentDidMount() {
@@ -351,7 +354,6 @@ class MapComponent extends React.Component {
 	}
 
 	viewMission(num){
-		// TODO: mission not being shown in first function call. Displays only on second call.
 
 		this.missionNumber = num;
 
@@ -536,6 +538,20 @@ class MapComponent extends React.Component {
 		// console.log(this.state.drawGeoFence);
 	}
 
+	toggleMissionPlanner(e) {
+		if (this.state.displayMissionPlanner) {
+			this.setState({
+				displayMissionPlanner: false
+			});
+			this.selectMissionPoint(0);
+		} else {
+			this.setState({
+				displayMissionPlanner: true
+			});
+		}
+
+	}
+
 	render() {
 		const position = [this.state.vehiclePosition.latitude, this.state.vehiclePosition.longitude];
 		const mapCenter = [this.state.mapCenter.latitude, this.state.mapCenter.longitude];
@@ -618,6 +634,11 @@ class MapComponent extends React.Component {
 		</Marker>,
 		<Circle center={position} radius={this.state.positionError}></Circle>] : null;
 
+		const MissionPlannerPanels = (this.state.displayMissionPlanner) ?
+		<Row>
+			<MissionPlanner selectMissionPointFunc={this.selectMissionPoint} addNewMissionFunc={this.addNewMission} cancelNewMissionFunc={this.cancelNewMission} viewMissionFunc={this.viewMission} missions={this.state.missions} management={this.management}/>
+		</Row> :
+		null;
 
 
 		return (
@@ -661,10 +682,13 @@ class MapComponent extends React.Component {
 							<Button type="submit" onClick={this.enableDrawGeofence}>Draw GeoFence</Button>
 							{drawGeoFenceOptions}
 						</div>
+						<div>
+							<Button type="submit" onClick={this.toggleMissionPlanner}>MissionPlanner</Button>
+						</div>
 					</Row>
-					<Row>
-						<MissionPlanner selectMissionPointFunc={this.selectMissionPoint} addNewMissionFunc={this.addNewMission} cancelNewMissionFunc={this.cancelNewMission} viewMissionFunc={this.viewMission} missions={this.state.missions} management={this.management}/>
-					</Row>
+
+					{MissionPlannerPanels}
+
 					<CursorPositionComponent position={this.state.cursorPosition} />
 				</Container>
 			</div>

--- a/experiments/WebUI/src/components/content/MapComponent.js
+++ b/experiments/WebUI/src/components/content/MapComponent.js
@@ -9,7 +9,7 @@ import CoordSys from '../../assets/CoordSys.js';
 
 import { FjageHelper } from "../../assets/fjageHelper.js";
 import { Management } from "../../assets/jc2.js";
-import { mapPin, readyMarker, notReadyMarker } from "../../assets/MapIcons.js";
+import { mapPin, mapPinSelected, readyMarker, notReadyMarker } from "../../assets/MapIcons.js";
 // import ManualCommands from '../../assets/ManualCommands.js';
 import ToolbarComponent from '../ToolbarComponent';
 
@@ -131,7 +131,8 @@ class MapComponent extends React.Component {
 			MissionDesignMode: false,
 
 			missions: null, //all missions
-			newMission: []
+			newMission: [],
+			selectedMissionPoint: 0
 
 		};
 
@@ -162,6 +163,8 @@ class MapComponent extends React.Component {
 
 		this.vehicleId = null;
 		// this.missions = null;
+
+		this.selectMissionPoint = this.selectMissionPoint.bind(this);
 	}
 
 	componentDidMount() {
@@ -465,6 +468,12 @@ class MapComponent extends React.Component {
 		}
 	}
 
+	selectMissionPoint(index) {
+		this.setState({
+			selectedMissionPoint: index
+		});
+	}
+
 	openNewWindow(tab) {
 		const href = window.location.href;
 		const url = href.substring(0, href.lastIndexOf('/') + 1) + tab;
@@ -539,14 +548,26 @@ class MapComponent extends React.Component {
 		var missionPtLatLngs = [];
 		this.state.missionPoints.forEach((missionPoint, i) => {
 			var x = missionPoint[0], y = missionPoint[1], lat = missionPoint[2], long = missionPoint[3];
-			MissionPointsMarkers.push(
-				<Marker icon={mapPin} key={i} position={[lat, long]}>
-					<Popup>
-						Lat: {lat}, Long: {long} <br/>
-						x: {x}, y: {y}
-					</Popup>
-				</Marker>
-			);
+			if (this.state.selectedMissionPoint == i+1) {
+				MissionPointsMarkers.push(
+					<Marker icon={mapPinSelected} key={i} position={[lat, long]}>
+						<Popup>
+							Lat: {lat}, Long: {long} <br/>
+							x: {x}, y: {y}
+						</Popup>
+					</Marker>
+				);
+			} else {
+				MissionPointsMarkers.push(
+					<Marker icon={mapPin} key={i} position={[lat, long]}>
+						<Popup>
+							Lat: {lat}, Long: {long} <br/>
+							x: {x}, y: {y}
+						</Popup>
+					</Marker>
+				);
+			}
+
 			missionPtLatLngs.push([lat, long]);
 		});
 
@@ -642,7 +663,7 @@ class MapComponent extends React.Component {
 						</div>
 					</Row>
 					<Row>
-						<MissionPlanner addNewMissionFunc={this.addNewMission} cancelNewMissionFunc={this.cancelNewMission} viewMissionFunc={this.viewMission} missions={this.state.missions} management={this.management}/>
+						<MissionPlanner selectMissionPointFunc={this.selectMissionPoint} addNewMissionFunc={this.addNewMission} cancelNewMissionFunc={this.cancelNewMission} viewMissionFunc={this.viewMission} missions={this.state.missions} management={this.management}/>
 					</Row>
 					<CursorPositionComponent position={this.state.cursorPosition} />
 				</Container>

--- a/experiments/WebUI/src/components/content/MissionPlanner.js
+++ b/experiments/WebUI/src/components/content/MissionPlanner.js
@@ -17,7 +17,7 @@ class MissionPlanner extends React.Component {
 
 		return (
 			<div className="MissionPlannerContainer">
-				<MissionTreeViewComponent management={this.props.management} drawNewMissionFunc={this.props.drawNewMissionFunc} viewMissionFunc={this.props.viewMissionFunc} missions={this.props.missions}/>
+				<MissionTreeViewComponent management={this.props.management} addNewMissionFunc={this.props.addNewMissionFunc} cancelNewMissionFunc={this.props.cancelNewMissionFunc} viewMissionFunc={this.props.viewMissionFunc} missions={this.props.missions}/>
 			</div>
 		);
 	}

--- a/experiments/WebUI/src/components/content/MissionPlanner.js
+++ b/experiments/WebUI/src/components/content/MissionPlanner.js
@@ -17,7 +17,7 @@ class MissionPlanner extends React.Component {
 
 		return (
 			<div className="MissionPlannerContainer">
-				<MissionTreeViewComponent management={this.props.management} addNewMissionFunc={this.props.addNewMissionFunc} cancelNewMissionFunc={this.props.cancelNewMissionFunc} viewMissionFunc={this.props.viewMissionFunc} missions={this.props.missions}/>
+				<MissionTreeViewComponent management={this.props.management} selectMissionPointFunc={this.props.selectMissionPointFunc} addNewMissionFunc={this.props.addNewMissionFunc} cancelNewMissionFunc={this.props.cancelNewMissionFunc} viewMissionFunc={this.props.viewMissionFunc} missions={this.props.missions}/>
 			</div>
 		);
 	}

--- a/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
+++ b/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
@@ -5,7 +5,7 @@ import { ListGroup } from 'react-bootstrap';
 import MLegInfoComponent from './MLegInfoComponent';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+import { faTrashAlt, faTimes, faSave } from '@fortawesome/free-solid-svg-icons'
 
 
 const styles = StyleSheet.create({
@@ -29,7 +29,8 @@ class CursorPositionComponent extends React.Component {
 
 		this.state = {
 			selectedMission: 0,
-			selectedMLeg: 0
+			selectedMLeg: 0,
+			addMissionMode: false
 		}
 
 	}
@@ -58,7 +59,25 @@ class CursorPositionComponent extends React.Component {
 
 	addNewMission(e) {
 		console.log("add new mission");
-		this.props.drawNewMissionFunc();
+		this.props.addNewMissionFunc();
+		this.setState({
+			addMissionMode: true
+		});
+	}
+
+	cancelAddMission(e) {
+		this.props.cancelNewMissionFunc();
+		this.setState({
+			addMissionMode: false
+		});
+	}
+
+	saveNewMission(){
+		// Yet to be implemented. Save newest mission.
+		console.log("Saved new mission");
+		this.setState({
+			addMissionMode: false
+		});
 	}
 
 	deleteMission(missionNumber) {
@@ -79,8 +98,9 @@ class CursorPositionComponent extends React.Component {
 				var missionLegList = [];
 				mission.forEach((missionLeg, j) => {
 					var activeMleg = (this.state.selectedMLeg == j+1) ? "active" : "" ;
-					missionLegList.push(<ListGroup.Item action className={activeMleg} onClick={() => this.selectMleg(j+1)}>{missionLeg.taskID.substring(0, missionLeg.taskID.indexOf("MT") + 2)} : {missionLeg.mp.x}, {missionLeg.mp.y}, {missionLeg.mp.z}</ListGroup.Item>);
+					missionLegList.push(<ListGroup.Item action className={activeMleg} onClick={() => this.selectMleg(j+1)}>{missionLeg.taskID.substring(0, missionLeg.taskID.indexOf("MT") + 2)} : {missionLeg.mp.x.toFixed(2)}, {missionLeg.mp.y.toFixed(2)}, {missionLeg.mp.z.toFixed(2)}</ListGroup.Item>);
 				});
+
 				missionLegList.push(<ListGroup.Item action > + </ListGroup.Item>);
 
 				var nestedClass = (this.state.selectedMission === (i+1)) ? "show-nested" : "hide-nested";
@@ -96,11 +116,19 @@ class CursorPositionComponent extends React.Component {
 
 
 			missionLeg = (this.state.selectedMission > 0 && this.state.selectedMLeg > 0) ? this.props.missions[this.state.selectedMission - 1][this.state.selectedMLeg - 1] : null;
-			console.log(missionLeg);
+			// console.log(missionLeg);
 		}
-		missionList.push(
-			<ListGroup.Item onClick={() => this.addNewMission()} className="addMissionBtn"> + </ListGroup.Item>
-		);
+		if (this.state.addMissionMode === false) {
+			missionList.push(<ListGroup.Item onClick={() => this.addNewMission()} className="addMissionBtn"> + </ListGroup.Item>);
+		} else {
+			missionList.push(
+				<ListGroup.Item>
+					<FontAwesomeIcon className="cancelAddMissionBtn" icon={faTimes} onClick={() => this.cancelAddMission()} title="Cancel New Mission"/>
+					<FontAwesomeIcon className="saveNewMissionBtn" icon={faSave} onClick={() => this.saveNewMission()} title="Save New Mission"/>
+				</ListGroup.Item>
+			);
+		}
+
 
 		return (
 			<div>
@@ -109,7 +137,7 @@ class CursorPositionComponent extends React.Component {
 						{missionList}
 					</ul>
 				</div>
-				<MLegInfoComponent missionLeg={missionLeg}/>
+				<MLegInfoComponent editMode={this.state.addMissionMode} refreshMissionMarkersFunc={this.props.viewMissionFunc} missionIndex={this.state.selectedMission} missionLeg={missionLeg}/>
 			</div>
 		);
 	}

--- a/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
+++ b/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
@@ -81,12 +81,12 @@ class CursorPositionComponent extends React.Component {
 					var activeMleg = (this.state.selectedMLeg == j+1) ? "active" : "" ;
 					missionLegList.push(<ListGroup.Item action className={activeMleg} onClick={() => this.selectMleg(j+1)}>{missionLeg.taskID.substring(0, missionLeg.taskID.indexOf("MT") + 2)} : {missionLeg.mp.x}, {missionLeg.mp.y}, {missionLeg.mp.z}</ListGroup.Item>);
 				});
-				// missionLegList.push(<ListGroup.Item action > + </ListGroup.Item>);
+				missionLegList.push(<ListGroup.Item action > + </ListGroup.Item>);
 
 				var nestedClass = (this.state.selectedMission === (i+1)) ? "show-nested" : "hide-nested";
 				var caretDown = (this.state.selectedMission === (i+1)) ? "caret caret-down" : "caret";
 				missionList.push(
-					<ListGroup.Item><span onClick={() => this.selectMission(i+1)} className={caretDown}>Mission No. {i+1}</span>
+					<ListGroup.Item><span onClick={() => this.selectMission(i+1)} className={caretDown}>Mission No. {i+1}</span> <FontAwesomeIcon className="deleteMissionBtn" icon={faTrashAlt} onClick={() => this.deleteMission(i+1)} title="Delete Mission"/>
 						<ListGroup className={nestedClass}>
 							{missionLegList}
 						</ListGroup>
@@ -98,9 +98,9 @@ class CursorPositionComponent extends React.Component {
 			missionLeg = (this.state.selectedMission > 0 && this.state.selectedMLeg > 0) ? this.props.missions[this.state.selectedMission - 1][this.state.selectedMLeg - 1] : null;
 			console.log(missionLeg);
 		}
-		// missionList.push(
-		// 	<ListGroup.Item onClick={() => this.addNewMission()} className="addMissionBtn"> + </ListGroup.Item>
-		// );
+		missionList.push(
+			<ListGroup.Item onClick={() => this.addNewMission()} className="addMissionBtn"> + </ListGroup.Item>
+		);
 
 		return (
 			<div>

--- a/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
+++ b/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
@@ -36,6 +36,7 @@ class CursorPositionComponent extends React.Component {
 	}
 
 	selectMission(index) {
+		this.props.selectMissionPointFunc(0);
 		if (index === this.state.selectedMission) {
 			this.setState({
 				selectedMission: 0,
@@ -55,6 +56,7 @@ class CursorPositionComponent extends React.Component {
 		this.setState({
 			selectedMLeg: index
 		});
+		this.props.selectMissionPointFunc(index);
 	}
 
 	addNewMission(e) {


### PR DESCRIPTION
Changes in this pull request include:
1. Enable editing missions and adding new ones. (Editing mission task properties)
2. Highlight select mission task on the map using a different mission point marker.
3. Add button to toggle mission planner.
4. Allow user to drag and drop markers to modify the new Geo-fence, add new markers using right click instead of left.
Resolves #23. 
Partially contributes to #13.  

