### PR TITLE
Mission planner

### DIFF
--- a/experiments/WebUI/src/assets/jc2.js
+++ b/experiments/WebUI/src/assets/jc2.js
@@ -53,6 +53,7 @@ export class Management {
      * @param {int} missionNumber Mission number.
      */
     runMission(missionNumber) {
+		console.log(missionNumber);
         this.getVehicleId()
             .then(vehicleId => {
                 const request = new OperatorCmdReq({
@@ -143,6 +144,34 @@ export class Management {
             });
     }
 
+	/**
+     * Updates a mission.
+     *
+     * @returns {Promise<Array>}
+     */
+    updateMission(updatedMission, missionNumber) {
+		console.log(updatedMission);
+		console.log(missionNumber);
+        return this._waitForReady()
+            .then(management => {
+                return new Promise((resolve, reject) => {
+                    const request = new UpdateMissionReq({
+                        recipient: this._managementAgentId,
+                        mission: updatedMission,
+                        missionNumber: missionNumber
+                    });
+                    this._gateway.request(request)
+                        .then(response => {
+                            if (response.perf === Performative.INFORM) {
+                                resolve(response.perf);
+                            } else {
+                                reject(response.perf);
+                            }
+                        });
+                });
+            });
+    }
+
     /**
      * Gets the vehicle ID.
      *
@@ -195,6 +224,27 @@ export class Management {
                 return new Promise((resolve, reject) => {
                     const request = new GetGeofenceReq({
                         recipient: this._managementAgentId,
+                    });
+                    this._gateway.request(request)
+                        .then(response => {
+                            if (response.perf === Performative.INFORM) {
+                                resolve(response.points);
+                            } else {
+                                reject(response.perf);
+                            }
+                        });
+                });
+            });
+    }
+
+    updateGeofence(updatedGeofence) {
+		console.log(updatedGeofence);
+        return this._waitForReady()
+            .then(management => {
+                return new Promise((resolve, reject) => {
+                    const request = new UpdateGeofenceReq({
+                        recipient: this._managementAgentId,
+                        points: updatedGeofence
                     });
                     this._gateway.request(request)
                         .then(response => {
@@ -459,6 +509,17 @@ export class GetGeofenceReq extends AbstractRequest {
     }
 }
 
+export class UpdateGeofenceReq extends AbstractRequest {
+     /**
+     * Constructs an GetGeofenceReq message.
+     *
+     * @param {Object} params parameters.
+     */
+    constructor(params) {
+        super('org.arl.jc2.messages.management.UpdateGeofenceReq', params);
+    }
+}
+
 export class GetHealthReq extends AbstractRequest {
 
     /**
@@ -564,6 +625,18 @@ export class GetMissionsReq extends AbstractRequest {
      */
     constructor(params) {
         super('org.arl.jc2.messages.management.GetMissionsReq', params);
+    }
+}
+
+export class UpdateMissionReq extends AbstractRequest {
+
+    /**
+     * Constructs an UpdateMissionReq message.
+     *
+     * @param {Object} params parameters.
+     */
+    constructor(params) {
+        super('org.arl.jc2.messages.management.UpdateMissionReq', params);
     }
 }
 

--- a/experiments/WebUI/src/assets/jc2.js
+++ b/experiments/WebUI/src/assets/jc2.js
@@ -66,6 +66,58 @@ export class Management {
             });
     }
 
+	/**
+     * Abort a mission.
+     *
+     */
+    abortMission() {
+        this.getVehicleId()
+            .then(vehicleId => {
+                const request = new OperatorCmdReq({
+                    recipient: this._captainAgentId,
+                    cmd: 'ABORT',
+                    vehicleID: vehicleId
+                });
+                // NOTE: no response expected
+                this._gateway.send(request);
+            });
+    }
+
+	/**
+     * Abort to home.
+     *
+     */
+    abortToHome() {
+        this.getVehicleId()
+            .then(vehicleId => {
+                const request = new OperatorCmdReq({
+                    recipient: this._captainAgentId,
+                    cmd: 'ABORT_TO_HOME',
+                    vehicleID: vehicleId
+                });
+                // NOTE: no response expected
+                this._gateway.send(request);
+            });
+    }
+
+	/**
+     * station keep.
+     *
+     */
+    stationKeep() {
+        this.getVehicleId()
+            .then(vehicleId => {
+                const request = new OperatorCmdReq({
+                    recipient: this._captainAgentId,
+                    cmd: 'STATIONKEEPING',
+                    vehicleID: vehicleId
+                });
+				console.log(request);
+                // NOTE: no response expected
+                this._gateway.send(request);
+            });
+    }
+
     /**
      * Gets missions.
      *
@@ -512,5 +564,68 @@ export class GetMissionsReq extends AbstractRequest {
      */
     constructor(params) {
         super('org.arl.jc2.messages.management.GetMissionsReq', params);
+    }
+}
+
+
+//*************** Classes for different Mission types ***************
+
+export class SimpleMT extends AbstractRequest {
+
+    /**
+     * Constructs an SimpleMT mission task.
+     *
+     * @param {Object} params parameters.
+     */
+    constructor(params) {
+        super('org.arl.jc2.mtt.SimpleMT', params);
+    }
+}
+
+export class LawnMowerMT extends AbstractRequest {
+
+    /**
+     * Constructs an LawnMowerMT mission task.
+     *
+     * @param {Object} params parameters.
+     */
+    constructor(params) {
+        super('org.arl.jc2.mtt.LawnMowerMT', params);
+    }
+}
+
+export class StationKeepingMT extends AbstractRequest {
+
+    /**
+     * Constructs an StationKeepingMT mission task.
+     *
+     * @param {Object} params parameters.
+     */
+    constructor(params) {
+        super('org.arl.jc2.mtt.StationKeepingMT', params);
+    }
+}
+
+export class SwanArmMT extends AbstractRequest {
+
+    /**
+     * Constructs an SwanArmMT mission task.
+     *
+     * @param {Object} params parameters.
+     */
+    constructor(params) {
+        super('org.arl.jc2.mtt.SwanArmMT', params);
+    }
+}
+
+export class TargetLocMT extends AbstractRequest {
+
+    /**
+     * Constructs an TargetLocMT mission task.
+     *
+     * @param {Object} params parameters.
+     */
+    constructor(params) {
+        super('org.arl.jc2.mtt.TargetLocMT', params);
     }
 }

--- a/experiments/WebUI/src/components/App.js
+++ b/experiments/WebUI/src/components/App.js
@@ -65,13 +65,11 @@ class App extends React.Component {
 		const href = window.location.href;
 		const url = href.substring(0, href.lastIndexOf('/') + 1) + tab;
 		var w = parentWindow.open(url, tab, "width=600,height=600,menubar=0,toolbar=0,location=0,personalBar=0,status=0,resizable=1");
-	}
+		// Hack used to bring focus to child window opened from another child window (close and reopen)
+		w.close();
+		w = parentWindow.open(url, tab, "width=600,height=600,menubar=0,toolbar=0,location=0,personalBar=0,status=0,resizable=1");
 
-	// openToolbar(){
-	// 	const href = window.location.href;
-	// 	const url = href.substring(0, href.lastIndexOf('/') + 1) + 'Toolbar';
-	// 	window.open(url, "_blank", "width=800,height=100,menubar=0,toolbar=0,location=0,personalBar=0,status=0,resizable=1");
-	// }
+	}
 
 	toggleNav() {
 		var sidebar = document.getElementById("sidebar");
@@ -125,7 +123,6 @@ class App extends React.Component {
 											<Route path="/Diagnostics" component={() => <DiagnosticsComponent/>}/>
 											<Route path="/Sentuators" component={() => <SentuatorsComponent/>}/>
 											<Route path="/ScriptControl" component={() => <ScriptControl/>}/>
-											<Route path="/Toolbar" component={() => <ToolbarComponent onClick={(clickedItem) => {this.openNewWindow(window, clickedItem)}}/>}/>
 											<Route path="*" component={() => <MapComponent/>}/>
 											{/* <Route path="*" component={() => <Main onClick={() => {this.openToolbar()}}/>}/> */}
 										</Switch>

--- a/experiments/WebUI/src/components/content/MapComponent.js
+++ b/experiments/WebUI/src/components/content/MapComponent.js
@@ -18,7 +18,7 @@ import { Row, Container, Dropdown, Button, DropdownButton } from 'react-bootstra
 import { StyleSheet, css } from 'aphrodite';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCrosshairs, faUndo, faSave, faWindowClose, faHome, faBan, faSatellite } from '@fortawesome/free-solid-svg-icons'
+import { faCrosshairs, faUndo, faSave, faWindowClose, faHome, faBan, faSatellite, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -151,6 +151,7 @@ class MapComponent extends React.Component {
 		this.enableDrawGeofence = this.enableDrawGeofence.bind(this);
 		this.undoGeoFencePoint = this.undoGeoFencePoint.bind(this);
 		this.saveNewGeoFence = this.saveNewGeoFence.bind(this);
+		this.clearNewGeoFence = this.clearNewGeoFence.bind(this);
 		this.cancelNewGeoFence = this.cancelNewGeoFence.bind(this);
 
 		this.mapOnRightClick = this.mapOnRightClick.bind(this);
@@ -437,7 +438,8 @@ class MapComponent extends React.Component {
 	enableDrawGeofence(e){
 		if (!this.state.MissionPlannerEnabled) {
 			this.setState({
-				drawingGeoFence: true
+				drawingGeoFence: true,
+				drawGeoFence: this.state.geoFenceCoordinates
 			})
 		}
 	}
@@ -453,9 +455,16 @@ class MapComponent extends React.Component {
 	saveNewGeoFence(e){
 		// TODO: add code to save geofence on vehicle and replace current geofence.
 
+		console.log("Saving new geofence (To be added on backend)");
 		this.setState({
 			drawingGeoFence: false,
 			// geoFenceCoordinates: this.state.drawGeoFence,
+			drawGeoFence: []
+		});
+	}
+
+	clearNewGeoFence(e){
+		this.setState({
 			drawGeoFence: []
 		});
 	}
@@ -669,9 +678,10 @@ class MapComponent extends React.Component {
 		const vehiclePath = (this.state.displayVehiclePath && !this.state.drawingGeoFence) ? <Polyline id="vehiclePath" positions={this.state.polylineArray} color="yellow"></Polyline> : null;
 
 		const drawGeoFenceOptions = (this.state.drawingGeoFence) ? <div className="drawGeoFence_content">
-			<Button type="submit" onClick={this.undoGeoFencePoint}><FontAwesomeIcon icon={faUndo} color="#fff" /></Button>
-			<Button type="submit" onClick={this.saveNewGeoFence}><FontAwesomeIcon icon={faSave} color="#fff" /></Button>
-			<Button type="submit" onClick={this.cancelNewGeoFence}><FontAwesomeIcon icon={faWindowClose} color="#fff" /></Button>
+			<Button type="submit" title="Undo last point" onClick={this.undoGeoFencePoint}><FontAwesomeIcon icon={faUndo} color="#fff" /></Button>
+			<Button type="submit" title="Save Geofence" onClick={this.saveNewGeoFence}><FontAwesomeIcon icon={faSave} color="#fff" /></Button>
+			<Button type="submit" title="Cancel Geofence" onClick={this.cancelNewGeoFence}><FontAwesomeIcon icon={faWindowClose} color="#fff" /></Button>
+			<Button type="submit" title="Clear Geofence" onClick={this.clearNewGeoFence}><FontAwesomeIcon icon={faTrashAlt} color="#fff" /></Button>
 		</div> : null;
 
 		const drawGeoFenceMarkers = [];

--- a/experiments/WebUI/src/components/content/MapComponent.js
+++ b/experiments/WebUI/src/components/content/MapComponent.js
@@ -389,7 +389,7 @@ class MapComponent extends React.Component {
 			})
 			return;
 		}
-
+		this.state.displayMissionPts = true;
 		var missionPointsArray = this.state.missions[num];
 		var currentMission = [];
 		for (var i=0; i < missionPointsArray.length; i++){

--- a/experiments/WebUI/src/components/content/MapComponent.js
+++ b/experiments/WebUI/src/components/content/MapComponent.js
@@ -8,7 +8,7 @@ import MissionPlanner from './MissionPlanner';
 import CoordSys from '../../assets/CoordSys.js';
 
 import { FjageHelper } from "../../assets/fjageHelper.js";
-import { Management } from "../../assets/jc2.js";
+import { Management, TargetLocMT } from "../../assets/jc2.js";
 import { mapPin, mapPinSelected, readyMarker, notReadyMarker } from "../../assets/MapIcons.js";
 // import ManualCommands from '../../assets/ManualCommands.js';
 import ToolbarComponent from '../ToolbarComponent';
@@ -300,6 +300,10 @@ class MapComponent extends React.Component {
 				positionError: this.state.positionError - 1
 			})},
 		200);
+
+		var x = new TargetLocMT();
+		console.log(x);
+		console.log("hello");
 	}
 
 	componentDidUpdate() {
@@ -607,17 +611,17 @@ class MapComponent extends React.Component {
 
 	abortMission() {
 		console.log("Abort Mission!");
-		// this.management.abortMission();
+		this.management.abortMission();
 	}
 
 	stationKeep() {
 		console.log("Station Keep!");
-		// this.management.stationKeep();
+		this.management.stationKeep();
 	}
 
 	goHome() {
 		console.log("Go Home!");
-		// this.management.goHome();
+		this.management.abortToHome();
 	}
 
 	render() {

--- a/experiments/WebUI/src/components/content/MapComponent.js
+++ b/experiments/WebUI/src/components/content/MapComponent.js
@@ -498,7 +498,7 @@ class MapComponent extends React.Component {
 
 	checkCollinear(pointArray, point) {
 		// epsilon accounts for the error in checking if a point is collinear. Larger epsilon will result in wider range of points getting accepted as collinear(even those that lie further from the line segment).
-		var epsilon = 0.000001;
+		var epsilon = 0.0000005;
 		// check if the point lies between any 2 of the consecutive mission points.
 		for (var i = 1; i < pointArray.length; i++) {
 			var crossProduct = (point[1] - pointArray[i-1][1]) * (pointArray[i][0] - pointArray[i-1][0]) - (point[0] - pointArray[i-1][0]) * (pointArray[i][1] - pointArray[i-1][1]);

--- a/experiments/WebUI/src/components/content/MapComponent.js
+++ b/experiments/WebUI/src/components/content/MapComponent.js
@@ -303,7 +303,6 @@ class MapComponent extends React.Component {
 
 		var x = new TargetLocMT();
 		console.log(x);
-		console.log("hello");
 	}
 
 	componentDidUpdate() {
@@ -457,14 +456,18 @@ class MapComponent extends React.Component {
 	}
 
 	saveNewGeoFence(e){
-		// TODO: add code to save geofence on vehicle and replace current geofence.
-
-		console.log("Saving new geofence (To be added on backend)");
-		this.setState({
-			drawingGeoFence: false,
-			// geoFenceCoordinates: this.state.drawGeoFence,
-			drawGeoFence: []
+		console.log("Saving new geofence");
+		this.management.updateGeofence(this.state.drawGeoFence)
+		.then(response => {
+			this.setState({
+				drawingGeoFence: false,
+				geoFenceCoordinates: this.state.drawGeoFence,
+			});
+		})
+		.catch(reason => {
+			console.log('Could not update geofence ', reason);
 		});
+
 	}
 
 	clearNewGeoFence(e){
@@ -489,7 +492,7 @@ class MapComponent extends React.Component {
 	openNewWindow(tab) {
 		const href = window.location.href;
 		const url = href.substring(0, href.lastIndexOf('/') + 1) + tab;
-		var w = window.open(url, tab, "width=600,height=600,menubar=0,toolbar=0,location=0,personalBar=0,status=0,resizable=1");
+		var w = window.open(url, tab, "width=600,height=600,menubar=0,toolbar=0,location=0,personalBar=0,status=0,resizable=1").focus();
 	}
 
 	// executes on right click on map.
@@ -502,7 +505,6 @@ class MapComponent extends React.Component {
 			});
 
 		} else if (this.state.MissionPlannerEnabled && this.state.missionNumber !== -1) {
-
 			this.setState({
 				currentMission: [...this.state.currentMission, [e.latlng.lat, e.latlng.lng]]
 			});

--- a/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
+++ b/experiments/WebUI/src/components/content/MissionTreeViewComponent.js
@@ -65,6 +65,10 @@ class CursorPositionComponent extends React.Component {
 		console.log("add new mission");
 		var missionsArr = this.state.missions;
 		var editedMissions = this.state.editedMissions;
+		if (missionsArr === null) {
+			missionsArr = [];
+			editedMissions = [];
+		}
 
 		missionsArr.push([]);
 		editedMissions.push(1);
@@ -72,28 +76,28 @@ class CursorPositionComponent extends React.Component {
 		this.setState({
 			missions: missionsArr,
 			editedMissions: editedMissions,
-			selectedMission: this.state.missions.length,
+			selectedMission: missionsArr.length,
 			selectedMLeg: 0
 		});
-		this.props.viewMissionFunc(this.state.missions.length - 1);
+		this.props.viewMissionFunc(missionsArr.length - 1);
 
 	}
 
 	saveChanges(missionNumber) {
 		console.log("Saving changes for Mission " + missionNumber);
-		// Yet to be implemented on backend
-		// this.props.management.saveMissionChanges(missionNumber, this.state.missions[missionNumber - 1])
-		// 	.then(response => {
-		// 		console.log(response);
-		// 		var editedMissions = this.state.editedMissions;
-		// 		editedMissions[missionNumber - 1] = 0;
-		//		this.setState({
-		// 			editedMissions: editedMissions
-		// 		});
-		// 	})
-		// 	.catch(reason => {
-		// 		console.log('Error: could not save mission to the vehicle', reason);
-		// 	});
+
+		this.props.management.updateMission(this.state.missions[missionNumber - 1], missionNumber)
+			.then(response => {
+				console.log(response);
+				var editedMissions = this.state.editedMissions;
+				editedMissions[missionNumber - 1] = 0;
+				this.setState({
+					editedMissions: editedMissions
+				});
+			})
+			.catch(reason => {
+				console.log('Error: could not save mission to the vehicle', reason);
+			});
 	}
 
 	discardChanges(missionNumber) {
@@ -125,9 +129,23 @@ class CursorPositionComponent extends React.Component {
 	}
 
 	deleteMission(missionNumber) {
-		// Yet to be implemented on backend
+		// TODO: Yet to be implemented on backend
 		// this.props.management.deleteMission(missionNumber);
 		console.log("Deleting Mission " + missionNumber);
+	}
+
+	deleteMissionPt(missionNumber, missionPtNumber) {
+		console.log(missionNumber + " " + missionPtNumber);
+		var missions = this.state.missions
+		missions[missionNumber].splice(missionPtNumber, 1);
+		var editedMissions = this.state.editedMissions;
+		editedMissions[missionNumber] = 1;
+		this.setState({
+			missions: missions,
+			editedMissions: editedMissions
+		});
+		console.log(missionNumber);
+		this.props.viewMissionFunc(missionNumber);
 	}
 
 	render() {
@@ -142,7 +160,12 @@ class CursorPositionComponent extends React.Component {
 				var missionLegList = [];
 				mission.forEach((missionLeg, j) => {
 					var activeMleg = (this.state.selectedMLeg == j+1) ? "active" : "" ;
-					missionLegList.push(<ListGroup.Item action className={activeMleg} onClick={() => this.selectMleg(j+1)}>{missionLeg.taskID.substring(0, missionLeg.taskID.indexOf("MT") + 2)} : {missionLeg.mp.x.toFixed(2)}, {missionLeg.mp.y.toFixed(2)}, {missionLeg.mp.z.toFixed(2)}</ListGroup.Item>);
+					missionLegList.push(
+						<ListGroup.Item action className={activeMleg}>
+							<span onClick={() => this.selectMleg(j+1)}>{missionLeg.taskID.substring(0, missionLeg.taskID.indexOf("MT") + 2)} : {missionLeg.mp.x.toFixed(2)}, {missionLeg.mp.y.toFixed(2)}, {missionLeg.mp.z.toFixed(2)}</span>
+							<FontAwesomeIcon className="deleteMissionBtn" icon={faTrashAlt} onClick={() => this.deleteMissionPt(i,j)} title="Delete Mission Point"/>
+						</ListGroup.Item>
+					);
 				});
 
 				missionLegList.push(<ListGroup.Item className="AddMissionPointComment"> Right Click on map to add mission point </ListGroup.Item>);


### PR DESCRIPTION
Contains the following changes:
* Allow user to clear geofence and set current geofence when starting the drawGeofence mode. Partial fix for #34 
* add methods for abort, go home and stationkeeping. Fix #8
* Allow user to delete mission points. Partial fix for #13 
* Toggle display mission points on pressing view button/selecting in mission planner. Fix #10.
* MapUI: Allow inserting point between 2 other points if they are collinear. Fix #33 